### PR TITLE
fix(kepler): correct alpha/mu scaling bug in universal Kepler solver, harden propagate_universal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.1.0] - 2026-07-20
+
+### Fixed
+
+- **Universal Kepler solver — `alpha`/`mu` scaling bug**
+  - `UniversalKeplerParams::alpha` was computed as the raw vis-viva energy
+    `2E = v² − 2μ/r`, but the Stumpff engine, the Kepler residual/derivative
+    equations, the Lagrange f/g coefficients, and the `prelim_elliptic` /
+    `prelim_hyperbolic` / `prelim_parabolic` initial-guess heuristics all
+    require the reciprocal-semi-major-axis convention `alpha = -1/a`
+    (`= 2E / μ`). The missing division by `μ` made `propagate_universal`
+    fail to converge — or converge to a spurious multi-revolution root — on
+    real Kalman-filter state vectors (fink-fat), especially for gaps of
+    several weeks or more.
+  - Fixed across `propagation.rs`, `newton_solver.rs`,
+    `brent_dekker_solver.rs`, and `prelim_kepler/{prelim_elliptic,
+    prelim_hyperbolic, prelim_parabolic}.rs`.
+  - Verified against an independent two-body ODE integration
+    (`test_propag`..`test_propag4` in `src/kepler/propagation.rs`).
+- **`velocity_correction` — missing `sqrt(mu)` factor on `sig0`**
+  - `src/kepler/velocity.rs` computed the radial-velocity proxy as
+    `x2.dot(v2)` instead of `x2.dot(v2) / sqrt(mu)`, a second, independent
+    bug in the same Lagrange f/g machinery used by the Gauss IOD velocity
+    refinement loop (`initial_orbit_determination/gauss.rs`).
+  - Fixing it together with the `alpha` bug above restores agreement with
+    the Orbfit reference orbit in `gauss_test::test_solve_orbit` to the
+    original 1e-13 tolerance (it silently diverged while only one of the
+    two bugs was fixed).
+
+### Added
+
+- **`propagate_universal` test coverage** (`src/kepler/propagation.rs`)
+  - `tests_propagation_edge_cases` — deterministic tests for quasi-circular,
+    high-eccentricity, near-parabolic (both signs of `alpha`), and
+    hyperbolic orbits; `dt ≈ 0`; negative `dt`; survey-cadence gaps from 35
+    to 400+ days (including multi-revolution gaps); continuity across a gap
+    boundary; degenerate (zero-norm) position input; warm-start vs
+    cold-start consistency; and agreement between `NewtonRaphson`,
+    `BrentDecker`, and `Auto` solver kinds.
+  - `tests_propagation_invariants` — property-based tests (`proptest`)
+    checking invariants that must hold for any valid two-body state: no
+    panics, the Lagrange identity `f·ġ − g·ḟ = 1`, conservation of specific
+    orbital energy and angular momentum, forward/backward round-trip
+    consistency, solver-kind agreement, chained small steps vs. a single
+    large step, and continuity under a tiny input perturbation. Orbits and
+    time-of-flight gaps are sampled from distributions matching real
+    fink-fat/Kalman-filter usage (periapsis/eccentricity up to `e = 5`,
+    survey-cadence gaps biased toward the >30-day inter-lunation and
+    inter-season regimes actually seen with ZTF/LSST).
+
 ## [4.0.0] - 2026-07-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,7 +1969,7 @@ dependencies = [
 
 [[package]]
 name = "outfit"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "aberth",
  "ahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "outfit"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 license-file = "LICENSE"
 rust-version = "1.94.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,10 @@ name = "fit_full_iod_parallel"
 path = "examples/run_full_iod_parallel.rs"
 required-features = ["parallel"]
 
+[[bench]]
+name = "propagate_universal"
+harness = false
+
 [profile.dev]
 debug = false
 
@@ -98,6 +102,8 @@ debug = false
 opt-level = 3
 lto = "thin"
 codegen-units = 1
+# Keep debug symbols so `perf record --call-graph=dwarf` can resolve Rust
+# frames on the compiled bench binaries (target/release/deps/<bench>-*).
 debug = true
 
 [profile.release]

--- a/benches/propagate_universal.rs
+++ b/benches/propagate_universal.rs
@@ -1,0 +1,341 @@
+//! Criterion benchmarks for [`propagate_universal`], the two-body
+//! universal-variable propagator used by fink-fat's Kalman filter for every
+//! per-object state update (tens of thousands of calls in production).
+//!
+//! Fixtures reuse the exact `(position, velocity, dt)` triples already
+//! validated in `src/kepler/propagation.rs::tests_propagation_edge_cases`
+//! and `tests_propagation` (real fink-fat state) — each fixture below names
+//! its corresponding test for traceability.
+//!
+//! Groups
+//! ------
+//! * `propagate_universal/scenarios` — end-to-end cost per orbital regime /
+//!   gap length actually seen in production.
+//! * `propagate_universal/solver_kind` — `NewtonRaphson` vs `BrentDecker` vs
+//!   `Auto`, to quantify the cost of the automatic fallback.
+//! * `propagate_universal/warm_start_chain` — a 20-step daily-cadence chain
+//!   (as a Kalman filter would run it), cold-started every step vs
+//!   warm-started from the previous `psy`.
+//! * `kepler/components` — isolated cost of `prelim_kepuni` and `s_funct`,
+//!   the two functions called on every Newton/Brent-Dekker iteration.
+//!
+//! Run with `cargo bench --bench propagate_universal`. To profile with
+//! `perf` (matching the `tracking_analysis` workflow), build once with
+//! `cargo bench --bench propagate_universal --no-run`, then `perf record`
+//! directly against the resulting `target/release/deps/propagate_universal-*`
+//! executable, optionally filtering to one Criterion group by passing its
+//! name as an extra argument (Criterion's own CLI filter).
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use nalgebra::Vector3;
+use outfit::kepler::{
+    prelim_elliptic, prelim_hyperbolic, s_funct, ParabolicPrelimMethod, SolverKind, SolverParams,
+    SolverType, UniversalKeplerParams,
+};
+use outfit::{kepler::propagate_universal, GAUSS_GRAV};
+
+/// Reference MJD epoch (arbitrary; only `dt` matters for two-body dynamics).
+const T0: f64 = 60000.0;
+
+fn default_solver_type() -> SolverType {
+    SolverType {
+        kind: SolverKind::Auto,
+        params: SolverParams {
+            convergency: 2.220446049250313e-14,
+            psi_guess: None,
+            max_iter_prelim_kepuni: 20,
+            parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+        },
+    }
+}
+
+/// One `propagate_universal` input scenario, named after the corresponding
+/// test in `src/kepler/propagation.rs`.
+struct Scenario {
+    name: &'static str,
+    position: Vector3<f64>,
+    velocity: Vector3<f64>,
+    dt: f64,
+}
+
+fn scenarios() -> Vec<Scenario> {
+    vec![
+        // tests_propagation::test_propag — real fink-fat Kalman-filter state.
+        Scenario {
+            name: "real_fink_fat_state",
+            position: Vector3::new(
+                -8.264_959_160_036_185e-1,
+                3.919_660_608_486_096_3e-1,
+                2.229_919_607_182_842_5e-2,
+            ),
+            velocity: Vector3::new(
+                -5.447_367_111_934_2e-3,
+                -2.107_596_146_728_544e-2,
+                1.560_811_152_125_889_6e-3,
+            ),
+            dt: 1.992476899875328,
+        },
+        // tests_propagation_edge_cases::test_quasi_circular_orbit — a=2.3 AU, e=1e-4.
+        Scenario {
+            name: "quasi_circular",
+            position: Vector3::new(0.21053202031103074, 2.2808559935794808, 0.20574336652469302),
+            velocity: Vector3::new(
+                -0.011240896923812553,
+                0.0009286862636099264,
+                0.0012093812594121695,
+            ),
+            dt: 1.0,
+        },
+        // tests_propagation_edge_cases::test_high_eccentricity_near_perihelion — a=2.5 AU, e=0.95.
+        Scenario {
+            name: "high_eccentricity_near_perihelion",
+            position: Vector3::new(
+                -0.07334498751332834,
+                -0.33895907499571465,
+                -0.028392141622553987,
+            ),
+            velocity: Vector3::new(
+                0.016602035346734694,
+                -0.03512248571568977,
+                -0.00855803655134319,
+            ),
+            dt: 2.0,
+        },
+        // tests_propagation_edge_cases::test_near_parabolic_elliptic — alpha = -1e-6.
+        Scenario {
+            name: "near_parabolic_elliptic",
+            position: Vector3::new(-39.52202041820489, -31.796429108199263, -8.899233495929744),
+            velocity: Vector3::new(
+                -0.0021940078334573457,
+                -0.0024735491628538825,
+                -0.0007479533467381286,
+            ),
+            dt: 5.0,
+        },
+        // tests_propagation_edge_cases::test_near_parabolic_hyperbolic — alpha = +1e-6.
+        Scenario {
+            name: "near_parabolic_hyperbolic",
+            position: Vector3::new(-39.52295104602465, -31.79684024886987, -8.899322047228939),
+            velocity: Vector3::new(
+                0.002194072590815172,
+                0.0024735663723493223,
+                0.0007479554224776113,
+            ),
+            dt: 5.0,
+        },
+        // tests_propagation_edge_cases::test_hyperbolic_orbit — a=-1.5 AU, e=2.0.
+        Scenario {
+            name: "hyperbolic",
+            position: Vector3::new(1.249244222099196, 0.79545767943562, 0.31874549259903184),
+            velocity: Vector3::new(
+                0.011307076273210306,
+                -0.019273992715882825,
+                -0.00941294513552841,
+            ),
+            dt: 10.0,
+        },
+        // tests_propagation_edge_cases::test_gap_35_days_ztf_lsst_cadence.
+        Scenario {
+            name: "gap_35_days",
+            position: Vector3::new(-0.5081279057987266, 1.9247110895634725, 0.35100377520249654),
+            velocity: Vector3::new(
+                -0.01246619702904591,
+                -0.0016710189605835082,
+                0.00028431118257845765,
+            ),
+            dt: 35.0,
+        },
+        // tests_propagation_edge_cases::test_gap_400_days_multi_revolution.
+        Scenario {
+            name: "gap_400_days_multi_revolution",
+            position: Vector3::new(1.2047460759903845, 0.6820351942449735, -0.09343868944527914),
+            velocity: Vector3::new(
+                -0.006617740910480954,
+                0.009290304236214792,
+                0.0007113219381064047,
+            ),
+            dt: 400.0,
+        },
+    ]
+}
+
+fn bench_scenarios(c: &mut Criterion) {
+    let mut group = c.benchmark_group("propagate_universal/scenarios");
+    for scenario in scenarios() {
+        group.bench_function(scenario.name, |b| {
+            b.iter(|| {
+                black_box(propagate_universal(
+                    black_box(&scenario.position),
+                    black_box(&scenario.velocity),
+                    black_box(T0),
+                    black_box(T0 + scenario.dt),
+                    black_box(default_solver_type()),
+                ))
+            })
+        });
+    }
+    group.finish();
+}
+
+fn bench_solver_kind(c: &mut Criterion) {
+    let mut group = c.benchmark_group("propagate_universal/solver_kind");
+    let all_scenarios = scenarios();
+    let representative = [
+        &all_scenarios[0], // real_fink_fat_state: typical short arc
+        &all_scenarios[7], // gap_400_days_multi_revolution: hardest convergence case
+    ];
+
+    for scenario in representative {
+        for kind in [
+            SolverKind::NewtonRaphson,
+            SolverKind::BrentDecker,
+            SolverKind::Auto,
+        ] {
+            let mut solver_type = default_solver_type();
+            solver_type.kind = kind;
+            let id = format!("{}/{kind:?}", scenario.name);
+            group.bench_function(id, |b| {
+                b.iter(|| {
+                    black_box(propagate_universal(
+                        black_box(&scenario.position),
+                        black_box(&scenario.velocity),
+                        black_box(T0),
+                        black_box(T0 + scenario.dt),
+                        black_box(solver_type),
+                    ))
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
+/// 20-step daily-cadence chain, as a Kalman filter would run it, starting
+/// from the real fink-fat state (`tests_propagation::test_propag`).
+fn bench_warm_start_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("propagate_universal/warm_start_chain");
+
+    let start_position = Vector3::new(
+        -8.264_959_160_036_185e-1,
+        3.919_660_608_486_096_3e-1,
+        2.229_919_607_182_842_5e-2,
+    );
+    let start_velocity = Vector3::new(
+        -5.447_367_111_934_2e-3,
+        -2.107_596_146_728_544e-2,
+        1.560_811_152_125_889_6e-3,
+    );
+    const STEPS: usize = 20;
+    const STEP_DT: f64 = 1.0;
+
+    group.bench_function("cold", |b| {
+        b.iter(|| {
+            let mut position = start_position;
+            let mut velocity = start_velocity;
+            let mut t = T0;
+            for _ in 0..STEPS {
+                let solver_type = default_solver_type(); // psi_guess always None
+                let result = propagate_universal(
+                    black_box(&position),
+                    black_box(&velocity),
+                    t,
+                    t + STEP_DT,
+                    solver_type,
+                )
+                .expect("chain step should converge");
+                position = result.r1;
+                velocity = result.v1;
+                t += STEP_DT;
+            }
+            black_box((position, velocity))
+        })
+    });
+
+    group.bench_function("warm", |b| {
+        b.iter(|| {
+            let mut position = start_position;
+            let mut velocity = start_velocity;
+            let mut t = T0;
+            let mut psi_guess = None;
+            for _ in 0..STEPS {
+                let mut solver_type = default_solver_type();
+                solver_type.params.psi_guess = psi_guess;
+                let result = propagate_universal(
+                    black_box(&position),
+                    black_box(&velocity),
+                    t,
+                    t + STEP_DT,
+                    solver_type,
+                )
+                .expect("chain step should converge");
+                position = result.r1;
+                velocity = result.v1;
+                psi_guess = Some(result.psy);
+                t += STEP_DT;
+            }
+            black_box((position, velocity))
+        })
+    });
+
+    group.finish();
+}
+
+/// Isolated cost of the two functions called on every Newton/Brent-Dekker
+/// iteration inside `propagate_universal`: the initial-guess heuristic
+/// (`prelim_kepuni`, exercised here via its public `prelim_elliptic` /
+/// `prelim_hyperbolic` branches) and the Stumpff-like series `s_funct`.
+fn bench_components(c: &mut Criterion) {
+    let mu = GAUSS_GRAV * GAUSS_GRAV;
+    let mut group = c.benchmark_group("kepler/components");
+
+    let typical_elliptic_params = UniversalKeplerParams {
+        dt: 1.992476899875328,
+        r0: 0.9150028121122286,
+        sig0: -0.21648695899581272,
+        mu,
+        alpha: -0.554947829724638, // -1/a, a~1.8 AU
+        e0: 0.5005485966968782,
+        solver_type: default_solver_type(),
+    };
+    let near_parabolic_elliptic_params = UniversalKeplerParams {
+        alpha: -1e-6,
+        ..typical_elliptic_params
+    };
+    let typical_hyperbolic_params = UniversalKeplerParams {
+        alpha: 0.6666666666666666, // matches the hyperbolic scenario above (a=-1.5 AU)
+        r0: 1.5148744695454394,
+        sig0: 0.05,
+        e0: 2.0,
+        ..typical_elliptic_params
+    };
+
+    group.bench_function("prelim_elliptic/typical", |b| {
+        b.iter(|| black_box(prelim_elliptic(black_box(&typical_elliptic_params))))
+    });
+    group.bench_function("prelim_elliptic/near_parabolic", |b| {
+        b.iter(|| black_box(prelim_elliptic(black_box(&near_parabolic_elliptic_params))))
+    });
+    group.bench_function("prelim_hyperbolic/typical", |b| {
+        b.iter(|| black_box(prelim_hyperbolic(black_box(&typical_hyperbolic_params))))
+    });
+
+    // s_funct: small-|beta| power-series branch vs large-|beta|
+    // halving-and-duplication branch (see src/kepler/stumpff.rs).
+    group.bench_function("s_funct/small_beta", |b| {
+        b.iter(|| black_box(s_funct(black_box(2.1870299805300064), black_box(-0.5549))))
+    });
+    group.bench_function("s_funct/large_beta", |b| {
+        b.iter(|| black_box(s_funct(black_box(1258.2351352918577), black_box(-0.5549))))
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_scenarios,
+    bench_solver_kind,
+    bench_warm_start_chain,
+    bench_components
+);
+criterion_main!(benches);

--- a/src/kepler/brent_dekker_solver.rs
+++ b/src/kepler/brent_dekker_solver.rs
@@ -49,14 +49,16 @@ const PHI: f64 = 1.618_033_988_749_895;
 /// Evaluate the universal Kepler residual  $ f(\psi) $ .
 ///
 ///  $ f(\psi) = r_0 \cdot s_1(\psi,\alpha) + \sigma_0 \cdot s_2(\psi,\alpha)
-///            + \mu \cdot s_3(\psi,\alpha) - \Delta t $
+///            + s_3(\psi,\alpha) - \sqrt{\mu} \cdot \Delta t $
 ///
 /// A root of this function corresponds to the universal anomaly  $ \psi^* $  at
-/// time  $ \Delta t $ .
+/// time  $ \Delta t $ . `alpha` is the reciprocal semi-major-axis convention
+/// ( $ \alpha = -1/a $ ), so no extra `mu` factor is needed on the `s2`/`s3`
+/// terms — see [`UniversalKeplerParams`](crate::kepler::UniversalKeplerParams).
 #[inline(always)]
 fn kepler_residual(psi: f64, params: &UniversalKeplerParams) -> f64 {
     let (_, s1, s2, s3) = s_funct(psi, params.alpha);
-    params.r0 * s1 + params.sig0 * s2 + params.mu * s3 - params.dt
+    params.r0 * s1 + params.sig0 * s2 + s3 - params.mu.sqrt() * params.dt
 }
 
 // ---------------------------------------------------------------------------
@@ -183,6 +185,7 @@ fn bracket_kepler_root(psi0: f64, params: &UniversalKeplerParams) -> Option<(f64
 /// By convention, `b` is always the *better* approximation, i.e.
 ///  $ |f(b)| \leq |f(a)| $  is maintained as an invariant throughout the
 /// iteration.
+#[derive(Debug)]
 struct BrentState {
     /// Current left endpoint of the bracket.
     a: f64,
@@ -499,10 +502,12 @@ fn run_brent_dekker(
         }
 
         let (next_psi, was_bisection) = select_next_candidate(&state);
+
         let f_next = kepler_residual(next_psi, params);
 
         state.prev_step_length = (state.b - state.c).abs();
         state.prev_was_bisection = was_bisection;
+
         update_bracket(&mut state, next_psi, f_next);
 
         None

--- a/src/kepler/mod.rs
+++ b/src/kepler/mod.rs
@@ -166,6 +166,7 @@ pub use orbit_type::OrbitType;
 pub use params::{SolverKind, SolverParams, SolverType, UniversalKeplerParams};
 pub use prelim_kepler::prelim_elliptic::prelim_elliptic;
 pub use prelim_kepler::prelim_hyperbolic::prelim_hyperbolic;
+pub use prelim_kepler::prelim_parabolic::ParabolicPrelimMethod;
 pub use propagation::{propagate_universal, UniversalPropagResult};
 pub use stumpff::s_funct;
 pub use universal_kepler_solution::UniversalKeplerSolution;

--- a/src/kepler/newton_solver.rs
+++ b/src/kepler/newton_solver.rs
@@ -149,7 +149,7 @@ const MAX_RELATIVE_STEP_FACTOR: f64 = 2.0;
 /// * [`s_funct`](crate::kepler::s_funct) – Stumpff auxiliary functions.
 /// * [`prelim_kepuni`](crate::kepler::UniversalKeplerParams::prelim_kepuni) – Heuristic initial guess.
 pub fn solve_kepuni_with_guess(params: &UniversalKeplerParams) -> Option<UniversalKeplerSolution> {
-    let residual_tolerance = compute_residual_tolerance(params.dt);
+    let residual_tolerance = compute_residual_tolerance(params.mu.sqrt() * params.dt);
 
     let psi_initial = params
         .solver_type
@@ -196,24 +196,29 @@ pub fn solve_kepuni(params: &UniversalKeplerParams) -> Option<UniversalKeplerSol
 
 /// Compute the scale-aware residual tolerance.
 ///
-///  $ \varepsilon_f = 10\varepsilon \cdot (1 + |\Delta t|) $
+///  $ \varepsilon_f = 10\varepsilon \cdot (1 + |\sqrt{\mu}\Delta t|) $
 ///
 /// Mixing an absolute floor  $ 10\varepsilon $  with a relative component
-///  $ 10\varepsilon \cdot |\Delta t| $  keeps the criterion meaningful across
-/// the full range of flight times.
+///  $ 10\varepsilon \cdot |\sqrt{\mu}\Delta t| $  keeps the criterion
+/// meaningful across the full range of flight times. The residual is
+/// compared against  $ \sqrt{\mu}\Delta t $  (not raw  $ \Delta t $ ), so the
+/// tolerance is scaled accordingly.
 #[inline]
-fn compute_residual_tolerance(dt: f64) -> f64 {
-    10.0 * f64::EPSILON * (1.0 + dt.abs())
+fn compute_residual_tolerance(sqrt_mu_dt: f64) -> f64 {
+    10.0 * f64::EPSILON * (1.0 + sqrt_mu_dt.abs())
 }
 
 /// Evaluate the universal Kepler residual  $ f(\psi) $  and its derivative
 ///  $ f'(\psi) $  at the given universal anomaly.
 ///
-///  $ f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + \mu \cdot s_3 - \Delta t $
-///  $ f'(\psi) = r_0 \cdot s_0 + \sigma_0 \cdot s_1 + \mu \cdot s_2 $
+///  $ f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + s_3 - \sqrt{\mu} \cdot \Delta t $
+///  $ f'(\psi) = r_0 \cdot s_0 + \sigma_0 \cdot s_1 + s_2 $
 ///
 /// The derivative chain of the Stumpff functions gives
-///  $ \mathrm{d}s_k / \mathrm{d}\psi = s_{k-1} $ .
+///  $ \mathrm{d}s_k / \mathrm{d}\psi = s_{k-1} $ . `alpha` here is the
+/// reciprocal semi-major-axis convention ( $ \alpha = -1/a $ ), so no extra
+/// `mu` factor is needed on the `s2`/`s3` terms — see
+/// [`UniversalKeplerParams`](crate::kepler::UniversalKeplerParams).
 #[inline]
 fn kepler_residual_and_derivative(
     psi: f64,
@@ -221,8 +226,8 @@ fn kepler_residual_and_derivative(
 ) -> (f64, f64, (f64, f64, f64, f64)) {
     let stumpff @ (s0, s1, s2, s3) = s_funct(psi, params.alpha);
 
-    let residual = params.r0 * s1 + params.sig0 * s2 + params.mu * s3 - params.dt;
-    let derivative = params.r0 * s0 + params.sig0 * s1 + params.mu * s2;
+    let residual = params.r0 * s1 + params.sig0 * s2 + s3 - params.mu.sqrt() * params.dt;
+    let derivative = params.r0 * s0 + params.sig0 * s1 + s2;
 
     (residual, derivative, stumpff)
 }

--- a/src/kepler/params.rs
+++ b/src/kepler/params.rs
@@ -81,7 +81,10 @@ impl Default for SolverType {
 /// * `r0`: Heliocentric distance at the reference epoch t₀ (in AU).
 /// * `sig0`: Radial velocity component at t₀ (in AU/day).
 /// * `mu`: Standard gravitational parameter μ = GM (in AU³/day²).
-/// * `alpha`: Twice the specific orbital energy (2E).
+/// * `alpha`: Reciprocal semi-major axis, `alpha = -1/a = 2E/μ` (in 1/AU).
+///   This is the convention expected by [`s_funct`](crate::kepler::s_funct)
+///   and the rest of the universal-variable machinery — *not* the raw
+///   vis-viva `2E` (dimension velocity²).
 /// * `e0`: Orbital eccentricity (unitless).
 ///
 /// The associated method [`orbit_type`](UniversalKeplerParams::orbit_type)
@@ -97,7 +100,7 @@ pub struct UniversalKeplerParams {
     pub sig0: f64,
     /// Standard gravitational parameter μ = GM, in AU³/day².
     pub mu: f64,
-    /// Twice the specific orbital energy (alpha = 2E).
+    /// Reciprocal semi-major axis (alpha = -1/a = 2E/mu), in 1/AU.
     pub alpha: f64,
     /// Orbital eccentricity (unitless).
     pub e0: f64,
@@ -210,7 +213,7 @@ mod kepler_params_tests {
         // Recompute Stumpff functions from psi to catch any inconsistency
         // between the stored universal anomaly and the cached s.. values.
         let (_, s1, s2, s3) = s_funct(sol.universal_anomaly, params.alpha);
-        (params.r0 * s1 + params.sig0 * s2 + params.mu * s3 - params.dt).abs()
+        (params.r0 * s1 + params.sig0 * s2 + s3 - params.mu.sqrt() * params.dt).abs()
     }
 
     /// Build a [`UniversalKeplerParams`] for a near-circular elliptic orbit.
@@ -218,8 +221,8 @@ mod kepler_params_tests {
     /// Uses a semi-major axis `a` (AU) to derive `alpha` and a nearly-zero
     /// radial velocity proxy.
     fn elliptic_params(dt: f64, a: f64, kind: SolverKind) -> UniversalKeplerParams {
-        // alpha = -mu / a  (twice specific orbital energy for elliptic orbit)
-        let alpha = -MU_SUN / a;
+        // alpha = -1 / a  (reciprocal semi-major axis convention)
+        let alpha = -1.0 / a;
         // r0 ~ a for a near-circular orbit.
         let r0 = a;
         // sig0 ~ 0 for a circular orbit (radial velocity is zero at periapsis/apoapsis).
@@ -241,9 +244,9 @@ mod kepler_params_tests {
     /// Build a [`UniversalKeplerParams`] for a hyperbolic orbit.
     ///
     /// Uses a characteristic energy $C_3 > 0$ (AU²/day²) so that
-    /// $\alpha = C_3 > 0$.
+    /// $\alpha = C_3 / \mu > 0$.
     fn hyperbolic_params(dt: f64, c3: f64, kind: SolverKind) -> UniversalKeplerParams {
-        let alpha = c3; // positive energy -> hyperbolic
+        let alpha = c3 / MU_SUN; // positive energy -> hyperbolic
         let r0 = 1.5; // AU
         let sig0 = 0.001;
         UniversalKeplerParams {
@@ -688,7 +691,10 @@ mod tests_prelim_kepuni {
         let r0 = 1.3803870211345761;
         let sig0 = 3.701_354_484_003_874_8E-3;
         let mu = 2.959_122_082_855_911_5E-4;
-        let alpha = -1.642_158_377_771_140_7E-4;
+        // alpha = -1/a, the reciprocal semi-major-axis convention (see
+        // `UniversalKeplerParams::alpha` doc). Equal to the raw vis-viva
+        // `2E = -1.642_158_377_771_140_7E-4` (AU^2/day^2) divided by `mu`.
+        let alpha = -0.554_947_829_724_638_7;
         let e0 = 0.283_599_599_137_344_5;
 
         let params = UniversalKeplerParams {
@@ -701,21 +707,21 @@ mod tests_prelim_kepuni {
             solver_type: SolverType::default(),
         };
         let psi = params.prelim_kepuni().unwrap();
-        assert_eq!(psi, -15.327414893041848);
+        assert_eq!(psi, -0.2636637076378094);
 
         let params2 = UniversalKeplerParams {
-            alpha: 1.642_158_377_771_140_7E-4,
+            alpha: 0.554_947_829_724_638_7,
             ..params
         };
         let psi = params2.prelim_kepuni().unwrap();
-        assert_eq!(psi, -73.1875935362658);
+        assert_eq!(psi, -1.258980225923225);
 
         let params3 = UniversalKeplerParams {
             alpha: 0.0,
             ..params
         };
         let psi = params3.prelim_kepuni().unwrap();
-        assert_eq!(psi, -15.228233329763219);
+        assert_eq!(psi, -0.2568229151088884);
     }
 
     mod kepuni_prop_tests {

--- a/src/kepler/prelim_kepler/prelim_elliptic.rs
+++ b/src/kepler/prelim_kepler/prelim_elliptic.rs
@@ -39,7 +39,7 @@ fn initial_eccentric_anomaly_from_geometry(
 ///
 /// Algorithm
 /// ---------
-/// 1. Compute the semi-major axis `a0 = -μ / α` and mean motion `n = sqrt((-α)^3) / μ`.
+/// 1. Compute the semi-major axis `a0 = -1 / α` and mean motion `n = sqrt(μ) · sqrt((-α)^3)`.
 /// 2. If the eccentricity `e0` is very small, approximate `ψ` directly using a linear formula.
 /// 3. Otherwise, compute the initial eccentric anomaly `u0` from the orbital geometry and
 ///    correct its sign based on the radial velocity `sig0`.
@@ -74,8 +74,10 @@ pub fn prelim_elliptic(params: &UniversalKeplerParams) -> f64 {
     let max_iter = params.solver_type.params.max_iter_prelim_kepuni;
 
     // Step 1: semi-major axis and mean motion.
-    let semi_major_axis = -params.mu / params.alpha;
-    let mean_motion = (-params.alpha.powi(3)).sqrt() / params.mu;
+    // `alpha` is the reciprocal semi-major-axis convention (alpha = -1/a),
+    // so a0 = -1/alpha; mean motion n = sqrt(mu/a0^3) = sqrt(mu) * (-alpha)^{3/2}.
+    let semi_major_axis = -1.0 / params.alpha;
+    let mean_motion = params.mu.sqrt() * (-params.alpha.powi(3)).sqrt();
 
     // Step 2: special case, nearly circular orbit.
     if params.e0 < contr {

--- a/src/kepler/prelim_kepler/prelim_hyperbolic.rs
+++ b/src/kepler/prelim_kepler/prelim_hyperbolic.rs
@@ -9,8 +9,8 @@ use crate::kepler::UniversalKeplerParams;
 ///
 /// Algorithm
 /// ---------
-/// 1. Compute the semi-major axis `a0 = -μ / α` and the hyperbolic mean motion
-///    `n = sqrt(α³) / μ`.
+/// 1. Compute the semi-major axis `a0 = -1 / α` and the hyperbolic mean motion
+///    `n = sqrt(μ) · sqrt(α³)`.
 /// 2. Compute the initial hyperbolic eccentric anomaly `F₀` from the geometry,
 ///    using:
 ///    cosh(F₀) = (1 - r₀ / a₀) / e₀
@@ -43,9 +43,12 @@ use crate::kepler::UniversalKeplerParams;
 /// * [`prelim_elliptic`](crate::kepler::prelim_elliptic) – Equivalent routine for elliptical orbits.
 /// * [`solve_kepuni`](crate::kepler::solve_kepuni) – Refines ψ by solving the universal Kepler equation.
 pub fn prelim_hyperbolic(params: &UniversalKeplerParams) -> f64 {
-    // Step 1: semi-major axis (negative for hyperbolic orbits) and hyperbolic mean motion.
-    let semi_major_axis = -params.mu / params.alpha;
-    let mean_motion = params.alpha.powi(3).sqrt() / params.mu;
+    // Step 1: semi-major axis (negative for hyperbolic orbits) and hyperbolic
+    // mean motion. `alpha` is the reciprocal semi-major-axis convention
+    // (alpha = -1/a, i.e. alpha > 0 for a < 0 hyperbolic orbits), so
+    // a0 = -1/alpha; mean motion n = sqrt(mu/(-a0)^3) = sqrt(mu) * alpha^{3/2}.
+    let semi_major_axis = -1.0 / params.alpha;
+    let mean_motion = params.mu.sqrt() * params.alpha.powi(3).sqrt();
 
     // Step 2: hyperbolic anomaly at epoch, sign-corrected by radial velocity.
     let initial_hyperbolic_anomaly = initial_hyperbolic_anomaly_from_geometry(

--- a/src/kepler/prelim_kepler/prelim_parabolic.rs
+++ b/src/kepler/prelim_kepler/prelim_parabolic.rs
@@ -22,11 +22,11 @@
 //! ```
 //!
 //! Substituting into the universal Kepler equation
-//! `r0 * s1 + sig0 * s2 + mu * s3 = dt` gives a **cubic polynomial in
+//! `r0 * s1 + sig0 * s2 + s3 = sqrt(mu) * dt` gives a **cubic polynomial in
 //! `psi`**, with no division by `alpha` anywhere:
 //!
 //! ```text
-//! (mu / 6) * psi^3 + (sig0 / 2) * psi^2 + r0 * psi - dt = 0
+//! (1 / 6) * psi^3 + (sig0 / 2) * psi^2 + r0 * psi - sqrt(mu) * dt = 0
 //! ```
 //!
 //! This is the universal-variable equivalent of Barker's equation for
@@ -38,8 +38,8 @@
 //! # A cubic can have up to three real roots — and it matters here
 //!
 //! The cubic derivative is itself a quadratic,
-//! `f'(psi) = (mu/2) psi^2 + sig0 * psi + r0`, with discriminant
-//! `sig0^2 - 2 * mu * r0`. Whenever `sig0` is large enough (fast radial
+//! `f'(psi) = (1/2) psi^2 + sig0 * psi + r0`, with discriminant
+//! `sig0^2 - 2 * r0`. Whenever `sig0` is large enough (fast radial
 //! motion, typically near pericenter — and, empirically, a *common* case for
 //! near-parabolic asteroid tracklets, not a rare edge case), this
 //! discriminant is positive, `f` is **not monotonic**, and the cubic can
@@ -79,7 +79,7 @@ pub enum ParabolicPrelimMethod {
     /// convergence criterion, and no failure mode on the non-monotonic
     /// branch: the correct real root is always identified analytically.
     /// This is the recommended default for this codebase, where the
-    /// non-monotonic case (`sig0^2 > 2 * mu * r0`) is common rather than
+    /// non-monotonic case (`sig0^2 > 2 * r0`) is common rather than
     /// exceptional.
     Cardano,
     /// Safeguarded Newton-Raphson iteration on the cubic residual, used
@@ -136,39 +136,40 @@ pub fn prelim_parabolic(params: &UniversalKeplerParams) -> f64 {
 /// `f'(psi)` at a given universal anomaly.
 ///
 /// ```text
-/// f(psi)  = (mu / 6) * psi^3 + (sig0 / 2) * psi^2 + r0 * psi - dt
-/// f'(psi) = (mu / 2) * psi^2 + sig0 * psi + r0
+/// f(psi)  = (1 / 6) * psi^3 + (sig0 / 2) * psi^2 + r0 * psi - sqrt(mu)*dt
+/// f'(psi) = (1 / 2) * psi^2 + sig0 * psi + r0
 /// ```
+///
+/// `scaled_time_of_flight` is `sqrt(mu) * dt`: the universal Kepler equation
+/// compares `r0*s1 + sig0*s2 + s3` against `sqrt(mu)*dt`, not raw `dt` (see
+/// [`UniversalKeplerParams`](crate::kepler::UniversalKeplerParams)); at
+/// `alpha = 0`, `s3 = psi^3/6` carries no `mu` factor, so none appears on the
+/// cubic term either — only the time term needs the `sqrt(mu)` scaling.
 #[inline]
 fn cubic_residual_and_derivative(
     universal_anomaly: f64,
     radial_distance: f64,
     radial_velocity_proxy: f64,
-    gravitational_parameter: f64,
-    time_of_flight: f64,
+    scaled_time_of_flight: f64,
 ) -> (f64, f64) {
-    let residual = gravitational_parameter / 6.0 * universal_anomaly.powi(3)
+    let residual = universal_anomaly.powi(3) / 6.0
         + radial_velocity_proxy / 2.0 * universal_anomaly.powi(2)
         + radial_distance * universal_anomaly
-        - time_of_flight;
+        - scaled_time_of_flight;
 
-    let derivative = gravitational_parameter / 2.0 * universal_anomaly.powi(2)
+    let derivative = universal_anomaly.powi(2) / 2.0
         + radial_velocity_proxy * universal_anomaly
         + radial_distance;
 
     (residual, derivative)
 }
 
-/// `true` if `f'(psi) = (mu/2) psi^2 + sig0*psi + r0` has real roots, i.e.
+/// `true` if `f'(psi) = (1/2) psi^2 + sig0*psi + r0` has real roots, i.e.
 /// the parabolic Kepler cubic `f` is **not** monotonic and can have up to
 /// three real roots. See the module documentation for why this matters.
 #[inline]
-fn is_cubic_non_monotonic(
-    radial_distance: f64,
-    radial_velocity_proxy: f64,
-    gravitational_parameter: f64,
-) -> bool {
-    radial_velocity_proxy * radial_velocity_proxy > 2.0 * gravitational_parameter * radial_distance
+fn is_cubic_non_monotonic(radial_distance: f64, radial_velocity_proxy: f64) -> bool {
+    radial_velocity_proxy * radial_velocity_proxy > 2.0 * radial_distance
 }
 
 // ---------------------------------------------------------------------------
@@ -197,8 +198,8 @@ fn is_cubic_non_monotonic(
 fn prelim_parabolic_newton(params: &UniversalKeplerParams, contr: f64, max_iter: usize) -> f64 {
     let radial_distance = params.r0;
     let radial_velocity_proxy = params.sig0;
-    let gravitational_parameter = params.mu;
     let time_of_flight = params.dt;
+    let scaled_time_of_flight = params.mu.sqrt() * time_of_flight;
 
     // Fast path: see the identical short-circuit in
     // `prelim_parabolic_cardano` for the rationale.
@@ -206,23 +207,18 @@ fn prelim_parabolic_newton(params: &UniversalKeplerParams, contr: f64, max_iter:
         return 0.0;
     }
 
-    if is_cubic_non_monotonic(
-        radial_distance,
-        radial_velocity_proxy,
-        gravitational_parameter,
-    ) {
+    if is_cubic_non_monotonic(radial_distance, radial_velocity_proxy) {
         return prelim_parabolic_cardano(params);
     }
 
-    let mut universal_anomaly = time_of_flight / radial_distance;
+    let mut universal_anomaly = scaled_time_of_flight / radial_distance;
 
     for _ in 0..max_iter {
         let (residual, derivative) = cubic_residual_and_derivative(
             universal_anomaly,
             radial_distance,
             radial_velocity_proxy,
-            gravitational_parameter,
-            time_of_flight,
+            scaled_time_of_flight,
         );
 
         if !derivative.is_finite() || derivative.abs() < 10.0 * f64::EPSILON {
@@ -268,15 +264,15 @@ fn prelim_parabolic_newton(params: &UniversalKeplerParams, contr: f64, max_iter:
 fn prelim_parabolic_cardano(params: &UniversalKeplerParams) -> f64 {
     let radial_distance = params.r0;
     let radial_velocity_proxy = params.sig0;
-    let gravitational_parameter = params.mu;
     let time_of_flight = params.dt;
+    let scaled_time_of_flight = params.mu.sqrt() * time_of_flight;
 
     // Fast path: at dt = 0 the constant term of the cubic vanishes
     // identically, so psi = 0 is an exact root regardless of r0 / sig0.
     // Going through the general depression + trigonometric algebra below
     // still finds this root, but only up to floating-point rounding (the
     // depressed coefficients can be many orders of magnitude larger than
-    // psi itself, e.g. when mu is tiny relative to r0 and sig0, so the
+    // psi itself, e.g. when sig0 is large relative to r0, so the
     // subtractions involved lose precision). Short-circuiting here avoids
     // that entirely for the one case where the exact answer is trivial.
     if time_of_flight == 0.0 {
@@ -284,12 +280,12 @@ fn prelim_parabolic_cardano(params: &UniversalKeplerParams) -> f64 {
     }
 
     // Step 1: normalize to a monic cubic `psi^3 + b*psi^2 + c*psi + d = 0`.
-    // The leading coefficient `mu / 6` is always strictly positive
-    // (mu = GM > 0), so this division is always safe.
-    let leading_coefficient = gravitational_parameter / 6.0;
+    // The leading coefficient `1 / 6` is a fixed constant, so this division
+    // is always safe.
+    let leading_coefficient = 1.0 / 6.0;
     let quadratic_coefficient = (radial_velocity_proxy / 2.0) / leading_coefficient;
     let linear_coefficient = radial_distance / leading_coefficient;
-    let constant_coefficient = -time_of_flight / leading_coefficient;
+    let constant_coefficient = -scaled_time_of_flight / leading_coefficient;
 
     // Step 2: depress the cubic via psi = y - depression_shift, with
     // depression_shift = quadratic_coefficient / 3. Standard depression
@@ -330,16 +326,14 @@ fn prelim_parabolic_cardano(params: &UniversalKeplerParams) -> f64 {
         &candidate_roots,
         radial_distance,
         radial_velocity_proxy,
-        gravitational_parameter,
-        time_of_flight,
+        scaled_time_of_flight,
     );
 
     polish_root_by_newton(
         selected_root,
         radial_distance,
         radial_velocity_proxy,
-        gravitational_parameter,
-        time_of_flight,
+        scaled_time_of_flight,
     )
 }
 
@@ -378,8 +372,7 @@ fn polish_root_by_newton(
     initial_estimate: f64,
     radial_distance: f64,
     radial_velocity_proxy: f64,
-    gravitational_parameter: f64,
-    time_of_flight: f64,
+    scaled_time_of_flight: f64,
 ) -> f64 {
     let mut universal_anomaly = initial_estimate;
 
@@ -388,8 +381,7 @@ fn polish_root_by_newton(
             universal_anomaly,
             radial_distance,
             radial_velocity_proxy,
-            gravitational_parameter,
-            time_of_flight,
+            scaled_time_of_flight,
         );
         if derivative == 0.0 || !derivative.is_finite() {
             break;
@@ -447,10 +439,9 @@ fn select_physical_root(
     candidate_roots: &[f64],
     radial_distance: f64,
     radial_velocity_proxy: f64,
-    gravitational_parameter: f64,
-    time_of_flight: f64,
+    scaled_time_of_flight: f64,
 ) -> f64 {
-    let linear_estimate = time_of_flight / radial_distance;
+    let linear_estimate = scaled_time_of_flight / radial_distance;
 
     let closest_to_linear_estimate = |roots: &[f64]| -> f64 {
         *roots
@@ -472,8 +463,7 @@ fn select_physical_root(
                 universal_anomaly,
                 radial_distance,
                 radial_velocity_proxy,
-                gravitational_parameter,
-                time_of_flight,
+                scaled_time_of_flight,
             );
             derivative >= 0.0
         })
@@ -518,8 +508,7 @@ mod prelim_parabolic_tests {
             universal_anomaly,
             params.r0,
             params.sig0,
-            params.mu,
-            params.dt,
+            params.mu.sqrt() * params.dt,
         )
         .0
     }
@@ -546,7 +535,7 @@ mod prelim_parabolic_tests {
     /// in the ordinary monotonic case.
     #[test]
     fn cardano_and_newton_agree_on_monotonic_case() {
-        let mut params = make_params(5.0, 1.3, 0.02); // sig0^2 << 2*mu*r0: monotonic
+        let mut params = make_params(5.0, 1.3, 0.02); // sig0^2 << 2*r0: monotonic
 
         let psi_cardano = prelim_parabolic(&params);
 
@@ -569,7 +558,7 @@ mod prelim_parabolic_tests {
             1.242_343_356_943_632_2,
             -5.995_054_062_733_072,
         );
-        assert!(is_cubic_non_monotonic(params.r0, params.sig0, params.mu));
+        assert!(is_cubic_non_monotonic(params.r0, params.sig0));
 
         let psi_cardano = prelim_parabolic(&params);
 
@@ -736,20 +725,18 @@ mod prelim_parabolic_tests {
                 let mut params = make_params(time_of_flight, radial_distance, radial_velocity_proxy);
                 params.solver_type.params.max_iter_prelim_kepuni = 100;
                 let universal_anomaly = prelim_parabolic(&params);
+                let scaled_time_of_flight = GRAVITATIONAL_PARAMETER.sqrt() * time_of_flight;
                 let (residual, _) = cubic_residual_and_derivative(
                     universal_anomaly,
                     radial_distance,
                     radial_velocity_proxy,
-                    GRAVITATIONAL_PARAMETER,
-                    time_of_flight,
+                    scaled_time_of_flight,
                 );
 
-                let term_magnitude_scale = (GRAVITATIONAL_PARAMETER / 6.0
-                    * universal_anomaly.powi(3))
-                .abs()
+                let term_magnitude_scale = (universal_anomaly.powi(3) / 6.0).abs()
                     + (radial_velocity_proxy / 2.0 * universal_anomaly.powi(2)).abs()
                     + (radial_distance * universal_anomaly).abs()
-                    + time_of_flight.abs();
+                    + scaled_time_of_flight.abs();
                 let tolerance = 1e-9 * term_magnitude_scale.max(1.0);
 
                 prop_assert!(
@@ -836,8 +823,8 @@ mod prelim_parabolic_tests {
             }
 
             /// In the regime where the cubic is *guaranteed* monotonic
-            /// (`sig0^2 <= 2 * mu * r0`, see [`is_cubic_non_monotonic`]),
-            /// `f` is strictly increasing and `f(0) = -dt`, so the sign of
+            /// (`sig0^2 <= 2 * r0`, see [`is_cubic_non_monotonic`]),
+            /// `f` is strictly increasing and `f(0) = -sqrt(mu)*dt`, so the sign of
             /// the unique real root must match the sign of `dt`. This is
             /// intentionally not asserted outside the monotonic regime —
             /// see the module-level note on the property that was dropped.
@@ -846,7 +833,7 @@ mod prelim_parabolic_tests {
                 radial_distance in radial_distance_strategy(),
                 time_of_flight in nonzero_time_of_flight_strategy(),
             ) {
-                // sig0 fixed to 0, trivially within the sig0^2 <= 2*mu*r0
+                // sig0 fixed to 0, trivially within the sig0^2 <= 2*r0
                 // bound for any r0 > 0, guaranteeing the monotonic regime.
                 let radial_velocity_proxy = 0.0;
                 let mut params = make_params(time_of_flight, radial_distance, radial_velocity_proxy);
@@ -855,7 +842,6 @@ mod prelim_parabolic_tests {
                 prop_assert!(!is_cubic_non_monotonic(
                     radial_distance,
                     radial_velocity_proxy,
-                    GRAVITATIONAL_PARAMETER,
                 ));
 
                 for method in [ParabolicPrelimMethod::Cardano, ParabolicPrelimMethod::Newton] {

--- a/src/kepler/propagation.rs
+++ b/src/kepler/propagation.rs
@@ -9,6 +9,7 @@ use crate::GAUSS_GRAV;
 use super::params::UniversalKeplerParams;
 
 /// Output of the universal-variable two-body propagator.
+#[derive(Debug)]
 pub struct UniversalPropagResult {
     /// Propagated position vector (au).
     pub r1: Vector3<f64>,
@@ -18,15 +19,15 @@ pub struct UniversalPropagResult {
     pub f_lag: f64,
     /// Lagrange coefficient $g$ such that $r_1 = f \cdot r_0 + g \cdot v_0$.
     pub g_lag: f64,
-    /// Time-derivative of $f$: $\dot{f} = -\frac{\mu}{r_0 r_1} S_1$.
+    /// Time-derivative of $f$: $\dot{f} = -\frac{\sqrt{\mu}}{r_0 r_1} S_1$.
     pub f_dot: f64,
-    /// Time-derivative of $g$: $\dot{g} = 1 - \frac{\mu}{r_1} S_2$.
+    /// Time-derivative of $g$: $\dot{g} = 1 - \frac{1}{r_1} S_2$.
     pub g_dot: f64,
     /// Universal anomaly $\psi$ (rad, generalized units).
     ///
     /// The root of the universal Kepler equation:
     ///
-    /// $$f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + \mu \cdot s_3 - \Delta t = 0$$
+    /// $$f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + s_3 - \sqrt{\mu} \cdot \Delta t = 0$$
     pub psy: f64,
 }
 
@@ -56,22 +57,28 @@ pub struct UniversalPropagResult {
 ///
 /// where:
 ///
-/// $$f = 1 - \frac{\mu}{r_0} s_2, \quad g = r_0 s_1 + \sigma_0 s_2$$
-/// $$\dot{f} = -\frac{\mu}{r_0 r_1} s_1, \quad \dot{g} = 1 - \frac{\mu}{r_1} s_2$$
+/// $$f = 1 - \frac{s_2}{r_0}, \quad g = \frac{r_0 s_1 + \sigma_0 s_2}{\sqrt{\mu}}$$
+/// $$\dot{f} = -\frac{\sqrt{\mu}}{r_0 r_1} s_1, \quad \dot{g} = 1 - \frac{s_2}{r_1}$$
 ///
 /// The radius at $t_1$ is recovered from the universal variable relation:
 ///
-/// $$r_1 = r_0 s_0 + \sigma_0 s_1 + \mu s_2$$
+/// $$r_1 = r_0 s_0 + \sigma_0 s_1 + s_2$$
 ///
 /// The normalized radial velocity proxy and energy parameter are:
 ///
 /// $$\sigma_0 = \frac{\mathbf{r}_0 \cdot \mathbf{v}_0}{\sqrt{\mu}}, \quad
-///   \alpha = v_0^2 - \frac{2\mu}{r_0}$$
+///   \alpha = \frac{v_0^2 - \frac{2\mu}{r_0}}{\mu} = -\frac{1}{a}$$
+///
+/// `alpha` is the reciprocal semi-major axis convention (dimension
+/// `1/length`) expected by [`s_funct`](crate::kepler::s_funct) and the rest
+/// of the universal-variable machinery — *not* the raw vis-viva $2E$ (which
+/// has dimension velocity$^2$). This division by $\mu$ is what keeps `alpha`
+/// dimensionally consistent with the (mu-free) formulas above.
 ///
 /// The eccentricity is derived from the specific angular momentum
 /// $h = \|\mathbf{r}_0 \times \mathbf{v}_0\|$:
 ///
-/// $$e_0 = \sqrt{1 + \frac{\alpha}{\mu^2} h^2}$$
+/// $$e_0 = \sqrt{1 + \frac{\alpha}{\mu} h^2}$$
 ///
 /// Arguments
 /// ---------
@@ -124,6 +131,7 @@ pub fn propagate_universal(
         initial_orbital_state(position, velocity, initial_radius, gravitational_parameter);
 
     let time_of_flight = t1 - t0;
+    let sqrt_mu = gravitational_parameter.sqrt();
 
     let params = UniversalKeplerParams {
         r0: initial_radius,
@@ -139,18 +147,17 @@ pub fn propagate_universal(
 
     let (s0, s1, s2, _) = kepler_solution.as_raw_stumpff();
 
-    let propagated_radius =
-        initial_radius * s0 + radial_velocity_proxy * s1 + gravitational_parameter * s2;
+    let propagated_radius = initial_radius * s0 + radial_velocity_proxy * s1 + s2;
     if propagated_radius < f64::EPSILON {
         return Err(OutfitError::DegenerateState(format!(
             "propagated radius r1 is zero or negative ({propagated_radius})"
         )));
     }
 
-    let lagrange_f = 1.0 - (gravitational_parameter / initial_radius) * s2;
-    let lagrange_g = initial_radius * s1 + radial_velocity_proxy * s2;
-    let lagrange_f_dot = -(gravitational_parameter / (initial_radius * propagated_radius)) * s1;
-    let lagrange_g_dot = 1.0 - (gravitational_parameter / propagated_radius) * s2;
+    let lagrange_f = 1.0 - s2 / initial_radius;
+    let lagrange_g = (initial_radius * s1 + radial_velocity_proxy * s2) / sqrt_mu;
+    let lagrange_f_dot = -(sqrt_mu / (initial_radius * propagated_radius)) * s1;
+    let lagrange_g_dot = 1.0 - s2 / propagated_radius;
 
     let propagated_position = lagrange_f * position + lagrange_g * velocity;
     let propagated_velocity = lagrange_f_dot * position + lagrange_g_dot * velocity;
@@ -171,8 +178,15 @@ pub fn propagate_universal(
 ///
 /// Returns `(radial_velocity_proxy, energy_parameter, eccentricity)` where:
 /// * `radial_velocity_proxy = (r0 . v0) / sqrt(mu)`,
-/// * `energy_parameter = alpha = |v0|^2 - 2*mu/r0`,
-/// * `eccentricity = sqrt(1 + (alpha/mu) * |r0 x v0|^2 / mu)`, clamped at 0.
+/// * `energy_parameter = alpha = (|v0|^2 - 2*mu/r0) / mu = -1/a`,
+/// * `eccentricity = sqrt(1 + alpha * |r0 x v0|^2 / mu)`, clamped at 0.
+///
+/// `alpha` is expressed in the `1/length` convention (reciprocal semi-major
+/// axis) expected by [`s_funct`](crate::kepler::s_funct) and the rest of the
+/// universal-variable machinery, not the raw vis-viva `2E = |v0|^2 - 2mu/r0`
+/// (dimension velocity^2): dividing by `mu` here is what keeps `alpha`,
+/// `s_funct`'s output, and the Lagrange coefficients below dimensionally
+/// consistent.
 fn initial_orbital_state(
     position: &Vector3<f64>,
     velocity: &Vector3<f64>,
@@ -181,13 +195,1004 @@ fn initial_orbital_state(
 ) -> (f64, f64, f64) {
     let initial_speed_squared = velocity.norm_squared();
     let radial_velocity_proxy = position.dot(velocity) / gravitational_parameter.sqrt();
-    let energy_parameter = initial_speed_squared - 2.0 * gravitational_parameter / initial_radius;
+    let energy_parameter = (initial_speed_squared - 2.0 * gravitational_parameter / initial_radius)
+        / gravitational_parameter;
     let angular_momentum_squared = position.cross(velocity).norm_squared();
     let eccentricity = (1.0
-        + (energy_parameter / gravitational_parameter) * angular_momentum_squared
-            / gravitational_parameter)
+        + energy_parameter * angular_momentum_squared / gravitational_parameter)
         .sqrt()
         .max(0.0);
 
     (radial_velocity_proxy, energy_parameter, eccentricity)
+}
+
+#[cfg(test)]
+mod tests_propagation {
+
+    use crate::kepler::{
+        prelim_kepler::prelim_parabolic::ParabolicPrelimMethod, SolverKind, SolverParams,
+    };
+
+    use super::*;
+
+    #[test]
+    fn test_propag() {
+        let position: Vector3<f64> = Vector3::new(
+            -8.264_959_160_036_185e-1,
+            3.919_660_608_486_096_3e-1,
+            2.229_919_607_182_842_5e-2,
+        );
+        let velocity: Vector3<f64> = Vector3::new(
+            -5.447_367_111_934_2e-3,
+            -2.107_596_146_728_544e-2,
+            1.560_811_152_125_889_6e-3,
+        );
+        let t0: f64 = 6.072_555_422_778_894e4;
+        let t1: f64 = 6.072_754_670_468_881_5e4;
+        let solver_type = SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: None,
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        };
+
+        let result = propagate_universal(&position, &velocity, t0, t1, solver_type)
+            .expect("propagation should converge on this real fink-fat Kalman-filter state");
+
+        // Ground truth obtained by independently integrating the two-body
+        // ODE (scipy `solve_ivp`, DOP853, rtol=1e-13) from the same initial
+        // state, cross-checked against a classical (a, e, E) Kepler-equation
+        // solve to 50 significant digits (mpmath). This is what exposed the
+        // `alpha`/`mu` scaling bug this test was written to catch.
+        let expected_r1 = Vector3::new(-0.83670766718652, 0.34968043043198, 0.02539102537652);
+        let expected_v1 = Vector3::new(-0.00479883489139, -0.02136507308119, 0.00154221064858);
+
+        assert!(
+            (result.r1 - expected_r1).norm() < 1e-9,
+            "propagated position mismatch: got {:?}, expected {expected_r1:?}",
+            result.r1
+        );
+        assert!(
+            (result.v1 - expected_v1).norm() < 1e-9,
+            "propagated velocity mismatch: got {:?}, expected {expected_v1:?}",
+            result.v1
+        );
+    }
+
+    #[test]
+    fn test_propag2() {
+        let position = Vector3::new(
+            -8.209_687_552_250_132e-1,
+            3.782_813_412_927_746e-1,
+            2.567_330_540_285_757_8e-2,
+        );
+        let velocity = Vector3::new(
+            -5.290_803_826_727_631e-3,
+            -2.120_754_244_524_938_2e-2,
+            1.601_930_231_829_977e-3,
+        );
+        let t0 = 6.072_555_414_035_025e4;
+        let t1 = 6.072_754_661_725_012_6e4;
+        let solver_type = SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: None,
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        };
+
+        let result = propagate_universal(&position, &velocity, t0, t1, solver_type)
+            .expect("propagation should converge on this real fink-fat Kalman-filter state");
+
+        // Ground truth obtained the same way as in `test_propag`: independent
+        // two-body ODE integration (scipy `solve_ivp`, DOP853, rtol=1e-13),
+        // cross-checked against a classical (a, e, E) Kepler-equation solve
+        // to 50 significant digits (mpmath).
+        let expected_r1 = Vector3::new(
+            -0.8308499934162212,
+            0.33573406780460846,
+            0.028843689480680244,
+        );
+        let expected_v1 = Vector3::new(
+            -0.004623556668660562,
+            -0.021495885832796668,
+            0.0015799033389438464,
+        );
+
+        assert!(
+            (result.r1 - expected_r1).norm() < 1e-9,
+            "propagated position mismatch: got {:?}, expected {expected_r1:?}",
+            result.r1
+        );
+        assert!(
+            (result.v1 - expected_v1).norm() < 1e-9,
+            "propagated velocity mismatch: got {:?}, expected {expected_v1:?}",
+            result.v1
+        );
+    }
+
+    #[test]
+    fn test_propag3() {
+        let position = Vector3::new(
+            -8.146_048_077_331_896e-1,
+            3.625_248_181_551_134_5e-1,
+            2.955_823_936_342_896e-2,
+        );
+        let velocity = Vector3::new(
+            -5.110_839_457_442_879e-3,
+            -2.135_829_675_942_633_3e-2,
+            1.649_090_267_256_617_4e-3,
+        );
+        let t0 = 6.072_555_403_967_375e4;
+        let t1 = 6.072_754_651_657_362_4e4;
+        let solver_type = SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: None,
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        };
+
+        let result = propagate_universal(&position, &velocity, t0, t1, solver_type)
+            .expect("propagation should converge on this real fink-fat Kalman-filter state");
+
+        // Ground truth obtained the same way as in `test_propag`: independent
+        // two-body ODE integration (scipy `solve_ivp`, DOP853, rtol=1e-13),
+        // cross-checked against a classical (a, e, E) Kepler-equation solve
+        // to 50 significant digits (mpmath).
+        let expected_r1 = Vector3::new(
+            -0.8241054960270079,
+            0.31967830644033735,
+            0.03281843272600818,
+        );
+        let expected_v1 = Vector3::new(
+            -0.004421449930078581,
+            -0.02164520905453043,
+            0.0016228438077301268,
+        );
+
+        assert!(
+            (result.r1 - expected_r1).norm() < 1e-9,
+            "propagated position mismatch: got {:?}, expected {expected_r1:?}",
+            result.r1
+        );
+        assert!(
+            (result.v1 - expected_v1).norm() < 1e-9,
+            "propagated velocity mismatch: got {:?}, expected {expected_v1:?}",
+            result.v1
+        );
+    }
+
+    #[test]
+    fn test_propag4() {
+        let position: Vector3<f64> = Vector3::new(
+            -7.955_255_488_725_416e-1,
+            2.548_930_678_464_935_7e-1,
+            4.862_868_244_426_771e-2,
+        );
+        let velocity: Vector3<f64> = Vector3::new(
+            4.922_319_532_929_707e-3,
+            -2.500_697_952_944_025_4e-2,
+            1.270_734_650_756_455_2e-3,
+        );
+        let t0: f64 = 6.072_754_601_265_45e4;
+        let t1: f64 = 6.072_754_948_485_463e4;
+        let solver_type = SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: Some(4.117043559944161),
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        };
+
+        let result = propagate_universal(&position, &velocity, t0, t1, solver_type)
+            .expect("propagation should converge on this real fink-fat Kalman-filter state");
+
+        // Ground truth obtained the same way as in `test_propag`: independent
+        // two-body ODE integration (scipy `solve_ivp`, DOP853, rtol=1e-13),
+        // cross-checked against a classical (a, e, E) Kepler-equation solve
+        // to 50 significant digits (mpmath).
+        let expected_r1 =
+            Vector3::new(-0.795508455171958, 0.25480623783297346, 0.04863309454122529);
+        let expected_v1 = Vector3::new(
+            0.004923714681911317,
+            -0.025007426475553637,
+            0.0012706493636607933,
+        );
+
+        assert!(
+            (result.r1 - expected_r1).norm() < 1e-9,
+            "propagated position mismatch: got {:?}, expected {expected_r1:?}",
+            result.r1
+        );
+        assert!(
+            (result.v1 - expected_v1).norm() < 1e-9,
+            "propagated velocity mismatch: got {:?}, expected {expected_v1:?}",
+            result.v1
+        );
+    }
+}
+
+/// Deterministic edge-case tests for [`propagate_universal`].
+///
+/// Each orbital regime below has its own ground truth, obtained the same way
+/// as the real-data cases in [`tests_propagation`]: independent two-body ODE
+/// integration (scipy `solve_ivp`, DOP853, `rtol=1e-13`), verified against a
+/// classical orbital-elements construction (the state vectors themselves are
+/// built from `(q, e, i, Ω, ω, anomaly)` elements, so the elements and the
+/// ODE integration are two independent checks on the same number).
+#[cfg(test)]
+mod tests_propagation_edge_cases {
+    use super::*;
+
+    use crate::kepler::{
+        prelim_kepler::prelim_parabolic::ParabolicPrelimMethod, SolverKind, SolverParams,
+    };
+
+    /// Reference MJD epoch used by every test below (arbitrary; only `dt`
+    /// matters for the two-body dynamics).
+    const T0: f64 = 60000.0;
+
+    fn default_solver_type() -> SolverType {
+        SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: None,
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        }
+    }
+
+    fn assert_vec_close(actual: Vector3<f64>, expected: Vector3<f64>, tol: f64, label: &str) {
+        let diff = (actual - expected).norm();
+        assert!(
+            diff < tol,
+            "{label} mismatch: got {actual:?}, expected {expected:?}, diff={diff:e} (tol={tol:e})"
+        );
+    }
+
+    #[test]
+    fn test_quasi_circular_orbit() {
+        // a=2.3 AU, e=1e-4: the near-circular MBA orbits a Kalman filter
+        // converges to most often.
+        let position = Vector3::new(0.21053202031103074, 2.2808559935794808, 0.20574336652469302);
+        let velocity = Vector3::new(
+            -0.011240896923812553,
+            0.0009286862636099264,
+            0.0012093812594121695,
+        );
+
+        let result = propagate_universal(&position, &velocity, T0, T0 + 1.0, default_solver_type())
+            .expect("quasi-circular orbit should converge");
+
+        let expected_r1 =
+            Vector3::new(0.19928860805173557, 2.2817569317219633, 0.20695024021604705);
+        let expected_v1 = Vector3::new(
+            -0.011245882006125182,
+            0.0008731863707498086,
+            0.0012043612300275948,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_high_eccentricity_near_perihelion() {
+        // a=2.5 AU, e=0.95, propagated 2 days from just past perihelion,
+        // where s2/s3 vary fastest.
+        let position = Vector3::new(
+            -0.07334498751332834,
+            -0.33895907499571465,
+            -0.028392141622553987,
+        );
+        let velocity = Vector3::new(
+            0.016602035346734694,
+            -0.03512248571568977,
+            -0.00855803655134319,
+        );
+
+        let result = propagate_universal(&position, &velocity, T0, T0 + 2.0, default_solver_type())
+            .expect("high-eccentricity orbit should converge");
+
+        let expected_r1 = Vector3::new(
+            -0.03938955874240485,
+            -0.4049151331571937,
+            -0.045107962550348484,
+        );
+        let expected_v1 = Vector3::new(
+            0.017239827060966013,
+            -0.03104380931069492,
+            -0.008159597609238184,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_near_parabolic_elliptic() {
+        // alpha = -1e-6 (a = 1e6 AU), q = 1.5 AU: stresses the
+        // `1/sqrt(|alpha|)` term in `prelim_elliptic` without alpha being
+        // exactly zero.
+        let position = Vector3::new(-39.52202041820489, -31.796429108199263, -8.899233495929744);
+        let velocity = Vector3::new(
+            -0.0021940078334573457,
+            -0.0024735491628538825,
+            -0.0007479533467381286,
+        );
+
+        let result = propagate_universal(&position, &velocity, T0, T0 + 5.0, default_solver_type())
+            .expect("near-parabolic (elliptic side) orbit should converge");
+
+        let expected_r1 = Vector3::new(-39.532989387326914, -31.808795993104074, -8.90297302170826);
+        let expected_v1 = Vector3::new(
+            -0.0021935798649369708,
+            -0.002473204832571767,
+            -0.0007478569735428885,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-8, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-8, "velocity");
+    }
+
+    #[test]
+    fn test_near_parabolic_hyperbolic() {
+        // alpha = +1e-6 (a = -1e6 AU), q = 1.5 AU: same stress as above, on
+        // the hyperbolic side (`prelim_hyperbolic`).
+        let position = Vector3::new(-39.52295104602465, -31.79684024886987, -8.899322047228939);
+        let velocity = Vector3::new(
+            0.002194072590815172,
+            0.0024735663723493223,
+            0.0007479554224776113,
+        );
+
+        let result = propagate_universal(&position, &velocity, T0, T0 + 5.0, default_solver_type())
+            .expect("near-parabolic (hyperbolic side) orbit should converge");
+
+        let expected_r1 = Vector3::new(-39.51197961256531, -31.784471555801662, -8.895582029083993);
+        let expected_v1 = Vector3::new(
+            0.0021945008425622334,
+            0.0024739108884688134,
+            0.0007480518443838213,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-8, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-8, "velocity");
+    }
+
+    #[test]
+    fn test_hyperbolic_orbit() {
+        // a=-1.5 AU, e=2.0: clearly unbound orbit (can occur if a Kalman
+        // state estimate momentarily overshoots into an unbound regime).
+        let position = Vector3::new(1.249244222099196, 0.79545767943562, 0.31874549259903184);
+        let velocity = Vector3::new(
+            0.011307076273210306,
+            -0.019273992715882825,
+            -0.00941294513552841,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 + 10.0, default_solver_type())
+                .expect("hyperbolic orbit should converge");
+
+        let expected_r1 = Vector3::new(1.356763056837531, 0.5995655052692187, 0.22337735587386795);
+        let expected_v1 = Vector3::new(
+            0.010175595301664717,
+            -0.019879144421132384,
+            -0.009648073244003378,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_dt_near_zero_returns_initial_state() {
+        // dt = 1e-8 day (~0.9 ms): intra-night cadence limit. The propagated
+        // state must be indistinguishable from the initial one.
+        let position = Vector3::new(
+            -8.264_959_160_036_185e-1,
+            3.919_660_608_486_096_3e-1,
+            2.229_919_607_182_842_5e-2,
+        );
+        let velocity = Vector3::new(
+            -5.447_367_111_934_2e-3,
+            -2.107_596_146_728_544e-2,
+            1.560_811_152_125_889_6e-3,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 + 1e-8, default_solver_type())
+                .expect("near-zero dt propagation should converge");
+
+        assert_vec_close(result.r1, position, 1e-8, "position");
+        assert_vec_close(result.v1, velocity, 1e-8, "velocity");
+    }
+
+    #[test]
+    fn test_negative_dt_backward_propagation() {
+        // a=1.8 AU, e=0.3, dt=-10 days: the Kalman filter also performs
+        // backward (smoothing) corrections.
+        let position = Vector3::new(
+            -1.9971284992478424,
+            -0.3712522565219666,
+            0.07103537618726069,
+        );
+        let velocity = Vector3::new(
+            -0.0011593869551458037,
+            -0.010998451678232324,
+            -0.0021125210607977427,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 - 10.0, default_solver_type())
+                .expect("backward propagation should converge");
+
+        let expected_r1 = Vector3::new(-1.981969219563329, -0.260669755669865, 0.09202082642052144);
+        let expected_v1 = Vector3::new(
+            -0.0018771502422668131,
+            -0.011112287894550531,
+            -0.0020830780553628306,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_gap_35_days_ztf_lsst_cadence() {
+        // a=2.2 AU, e=0.15, dt=+35 days: the concrete "gap > 30 days" case
+        // reported from real ZTF cadence, and the exact regime where the
+        // `alpha`/`mu` scaling bug (fixed by `test_propag`) manifested.
+        let position = Vector3::new(-0.5081279057987266, 1.9247110895634725, 0.35100377520249654);
+        let velocity = Vector3::new(
+            -0.01246619702904591,
+            -0.0016710189605835082,
+            0.00028431118257845765,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 + 35.0, default_solver_type())
+                .expect("35-day gap propagation should converge");
+
+        let expected_r1 = Vector3::new(-0.9305835567844181, 1.8256992698318637, 0.3534197183411793);
+        let expected_v1 = Vector3::new(
+            -0.011601678565060293,
+            -0.0039348889411689745,
+            -0.00014072224048158237,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_gap_45_days_negative() {
+        // Same object as the 35-day case, dt=-45 days: a larger gap, backward.
+        let position = Vector3::new(-0.5081279057987266, 1.9247110895634725, 0.35100377520249654);
+        let velocity = Vector3::new(
+            -0.01246619702904591,
+            -0.0016710189605835082,
+            0.00028431118257845765,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 - 45.0, default_solver_type())
+                .expect("45-day backward gap propagation should converge");
+
+        let expected_r1 = Vector3::new(0.06469927718927299, 1.9271232755936696, 0.3252726272245291);
+        let expected_v1 = Vector3::new(
+            -0.012836838087040878,
+            0.0016190222436126842,
+            0.0008615818662658044,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_gap_150_days_short_period_neo() {
+        // a=1.0 AU, e=0.4 (period ~365 days), dt=150 days: recovery after a
+        // long seasonal gap, still under one full revolution.
+        let position = Vector3::new(1.2047460759903845, 0.6820351942449735, -0.09343868944527914);
+        let velocity = Vector3::new(
+            -0.006617740910480954,
+            0.009290304236214792,
+            0.0007113219381064047,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 + 150.0, default_solver_type())
+                .expect("150-day gap propagation should converge");
+
+        let expected_r1 = Vector3::new(
+            -0.6120201957110859,
+            0.10949611603813385,
+            0.054394854746006055,
+        );
+        let expected_v1 = Vector3::new(
+            -0.0007514307771635531,
+            -0.02552809717488894,
+            -0.00032308624673825666,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_gap_400_days_multi_revolution() {
+        // Same object as the 150-day case, dt=400 days: exceeds the ~365-day
+        // period, so `psi` must span more than one revolution — the failure
+        // mode directly tied to the root cause fixed alongside `test_propag`.
+        let position = Vector3::new(1.2047460759903845, 0.6820351942449735, -0.09343868944527914);
+        let velocity = Vector3::new(
+            -0.006617740910480954,
+            0.009290304236214792,
+            0.0007113219381064047,
+        );
+
+        let result =
+            propagate_universal(&position, &velocity, T0, T0 + 400.0, default_solver_type())
+                .expect("multi-revolution 400-day gap propagation should converge");
+
+        let expected_r1 =
+            Vector3::new(0.8970232454981946, 0.9499966243304765, -0.06285450365091588);
+        let expected_v1 = Vector3::new(
+            -0.011011765095008376,
+            0.005846950052656893,
+            0.001037596639746061,
+        );
+
+        assert_vec_close(result.r1, expected_r1, 1e-9, "position");
+        assert_vec_close(result.v1, expected_v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_continuity_across_lunation_gap() {
+        // Same object as the 35-day case, evaluated at dt=34.9 and dt=35.1
+        // days: both must independently match their ground truth, which
+        // rules out a discontinuous jump (e.g. an internal solver-branch or
+        // revolution-count flip) between two very close gap lengths.
+        let position = Vector3::new(-0.5081279057987266, 1.9247110895634725, 0.35100377520249654);
+        let velocity = Vector3::new(
+            -0.01246619702904591,
+            -0.0016710189605835082,
+            0.00028431118257845765,
+        );
+
+        let before =
+            propagate_universal(&position, &velocity, T0, T0 + 34.9, default_solver_type())
+                .expect("dt=34.9 propagation should converge");
+        let after = propagate_universal(&position, &velocity, T0, T0 + 35.1, default_solver_type())
+            .expect("dt=35.1 propagation should converge");
+
+        assert_vec_close(
+            before.r1,
+            Vector3::new(-0.9294232358528046, 1.8260924582635572, 0.3534337324049776),
+            1e-9,
+            "position at dt=34.9",
+        );
+        assert_vec_close(
+            after.r1,
+            Vector3::new(-0.9317435714637801, 1.8253054805679922, 0.3534055879680079),
+            1e-9,
+            "position at dt=35.1",
+        );
+
+        // Sanity check on top of the ground-truth match: 0.2 days apart, the
+        // two positions should differ by an amount consistent with the
+        // local velocity (~|v|*0.2), not by a discontinuous jump.
+        let expected_scale = before.v1.norm() * 0.2;
+        let actual_gap = (after.r1 - before.r1).norm();
+        assert!(
+            actual_gap < 10.0 * expected_scale,
+            "unexpectedly large jump between dt=34.9 and dt=35.1: {actual_gap} (expected order {expected_scale})"
+        );
+    }
+
+    #[test]
+    fn test_degenerate_position_returns_err() {
+        let position = Vector3::new(0.0, 0.0, 0.0);
+        let velocity = Vector3::new(0.01, 0.0, 0.0);
+
+        let result = propagate_universal(&position, &velocity, T0, T0 + 1.0, default_solver_type());
+
+        assert!(
+            matches!(result, Err(OutfitError::DegenerateState(_))),
+            "expected DegenerateState error, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn test_warm_start_consistent_with_cold_start() {
+        let position = Vector3::new(
+            -8.264_959_160_036_185e-1,
+            3.919_660_608_486_096_3e-1,
+            2.229_919_607_182_842_5e-2,
+        );
+        let velocity = Vector3::new(
+            -5.447_367_111_934_2e-3,
+            -2.107_596_146_728_544e-2,
+            1.560_811_152_125_889_6e-3,
+        );
+
+        let base = propagate_universal(&position, &velocity, T0, T0 + 10.0, default_solver_type())
+            .expect("base propagation should converge");
+
+        let mut warm_solver_type = default_solver_type();
+        warm_solver_type.params.psi_guess = Some(base.psy);
+
+        let warm = propagate_universal(&position, &velocity, T0, T0 + 10.5, warm_solver_type)
+            .expect("warm-started propagation should converge");
+        let cold = propagate_universal(&position, &velocity, T0, T0 + 10.5, default_solver_type())
+            .expect("cold-started propagation should converge");
+
+        assert_vec_close(warm.r1, cold.r1, 1e-9, "position");
+        assert_vec_close(warm.v1, cold.v1, 1e-9, "velocity");
+    }
+
+    #[test]
+    fn test_solver_kind_agreement() {
+        let position = Vector3::new(
+            -8.264_959_160_036_185e-1,
+            3.919_660_608_486_096_3e-1,
+            2.229_919_607_182_842_5e-2,
+        );
+        let velocity = Vector3::new(
+            -5.447_367_111_934_2e-3,
+            -2.107_596_146_728_544e-2,
+            1.560_811_152_125_889_6e-3,
+        );
+        let t1 = T0 + 1.992476899875328;
+
+        let mut newton_solver_type = default_solver_type();
+        newton_solver_type.kind = SolverKind::NewtonRaphson;
+        let mut brent_solver_type = default_solver_type();
+        brent_solver_type.kind = SolverKind::BrentDecker;
+        let mut auto_solver_type = default_solver_type();
+        auto_solver_type.kind = SolverKind::Auto;
+
+        let newton = propagate_universal(&position, &velocity, T0, t1, newton_solver_type)
+            .expect("Newton-Raphson should converge");
+        let brent = propagate_universal(&position, &velocity, T0, t1, brent_solver_type)
+            .expect("Brent-Dekker should converge");
+        let auto = propagate_universal(&position, &velocity, T0, t1, auto_solver_type)
+            .expect("Auto should converge");
+
+        assert_vec_close(newton.r1, brent.r1, 1e-9, "Newton vs Brent position");
+        assert_vec_close(newton.v1, brent.v1, 1e-9, "Newton vs Brent velocity");
+        assert_vec_close(newton.r1, auto.r1, 1e-9, "Newton vs Auto position");
+        assert_vec_close(newton.v1, auto.v1, 1e-9, "Newton vs Auto velocity");
+    }
+}
+
+/// Property-based invariants for [`propagate_universal`].
+///
+/// Unlike [`tests_propagation_edge_cases`], these tests require no external
+/// ground truth: they check physical/mathematical invariants that must hold
+/// for *any* valid two-body state, sampled broadly across the orbital
+/// regimes and time-of-flight gaps a Kalman-filter-driven pipeline (fink-fat,
+/// fed by survey cadences such as ZTF/LSST) actually encounters — including
+/// gaps well beyond 30 days between observations, not just short arcs.
+#[cfg(test)]
+mod tests_propagation_invariants {
+    use super::*;
+
+    use crate::kepler::{
+        prelim_kepler::prelim_parabolic::ParabolicPrelimMethod, SolverKind, SolverParams,
+    };
+    use nalgebra::Rotation3;
+    use proptest::prelude::*;
+
+    const T0: f64 = 60000.0;
+
+    fn default_solver_type() -> SolverType {
+        SolverType {
+            kind: SolverKind::Auto,
+            params: SolverParams {
+                convergency: 2.220446049250313e-14,
+                psi_guess: None,
+                max_iter_prelim_kepuni: 20,
+                parabolic_solving_method: ParabolicPrelimMethod::Cardano,
+            },
+        }
+    }
+
+    /// Independent reimplementation of the specific-orbital-energy formula
+    /// (deliberately *not* reusing the private `initial_orbital_state`, so
+    /// this genuinely checks conservation rather than tautologically
+    /// re-deriving the same number the production code already computed).
+    fn specific_energy_alpha(position: &Vector3<f64>, velocity: &Vector3<f64>) -> f64 {
+        let mu = GAUSS_GRAV * GAUSS_GRAV;
+        let r = position.norm();
+        let v2 = velocity.norm_squared();
+        (v2 - 2.0 * mu / r) / mu
+    }
+
+    /// Generate a physically plausible heliocentric `(position, velocity)`
+    /// pair by sampling classical orbital elements `(q, e, true_anomaly, i,
+    /// Ω, ω)` and converting to Cartesian state via the standard
+    /// perifocal-frame conic formulas — valid uniformly across elliptic,
+    /// near-parabolic, and hyperbolic regimes (no Kepler-equation solve
+    /// needed, since the state is parametrised directly by true anomaly).
+    ///
+    /// `q` (periapsis distance) spans [0.05, 150] AU and `e` spans [0, 5),
+    /// matching the plausibility bounds already used for IOD
+    /// (`IODParams::r2_min_au`/`r2_max_au`/`max_ecc`). The resulting `r0` is
+    /// filtered back into a comparable [0.02, 500] AU range, since a raw
+    /// true-anomaly sweep on a near-parabolic/hyperbolic branch can
+    /// otherwise wander arbitrarily far from the Sun.
+    fn arb_heliocentric_state() -> impl Strategy<Value = (Vector3<f64>, Vector3<f64>)> {
+        (
+            0.05f64..150.0,                // periapsis distance q (AU)
+            0.0f64..5.0,                   // target eccentricity e
+            0.0f64..1.0,                   // true-anomaly fraction
+            0.0f64..std::f64::consts::PI,  // inclination
+            0.0f64..std::f64::consts::TAU, // ascending node longitude
+            0.0f64..std::f64::consts::TAU, // argument of periapsis
+        )
+            .prop_map(|(q, e, nu_frac, inclination, node, periapsis_arg)| {
+                let mu = GAUSS_GRAV * GAUSS_GRAV;
+
+                // True anomaly: unrestricted for ellipses; clamped to 90% of
+                // the asymptotic angle for parabola/hyperbola so `r` stays
+                // finite.
+                let true_anomaly = if e < 1.0 {
+                    nu_frac * std::f64::consts::TAU - std::f64::consts::PI
+                } else {
+                    let nu_max = (-1.0 / e).acos() * 0.9;
+                    (nu_frac * 2.0 - 1.0) * nu_max
+                };
+
+                let semi_latus_rectum = q * (1.0 + e);
+                let h = (mu * semi_latus_rectum).sqrt();
+                let radius = semi_latus_rectum / (1.0 + e * true_anomaly.cos());
+
+                let position_perifocal = Vector3::new(
+                    radius * true_anomaly.cos(),
+                    radius * true_anomaly.sin(),
+                    0.0,
+                );
+                let velocity_perifocal =
+                    (mu / h) * Vector3::new(-true_anomaly.sin(), e + true_anomaly.cos(), 0.0);
+
+                let rotation = Rotation3::from_axis_angle(&Vector3::z_axis(), node)
+                    * Rotation3::from_axis_angle(&Vector3::x_axis(), inclination)
+                    * Rotation3::from_axis_angle(&Vector3::z_axis(), periapsis_arg);
+
+                (rotation * position_perifocal, rotation * velocity_perifocal)
+            })
+            .prop_filter(
+                "r0 within a plausible heliocentric range",
+                |(position, _)| (0.02..500.0).contains(&position.norm()),
+            )
+    }
+
+    /// Time-of-flight strategy weighted to reflect real survey cadence
+    /// (ZTF/LSST) rather than an arbitrary uniform range: intra-night
+    /// timescales, inter-night arcs, inter-lunation gaps (the concrete
+    /// "more than 30 days between detections" case), and inter-season/
+    /// inter-opposition recoveries. Both signs are included, since the
+    /// Kalman filter also performs backward (smoothing) corrections.
+    fn arb_time_of_flight() -> impl Strategy<Value = f64> {
+        prop_oneof![
+            2 => -0.05f64..0.05,
+            3 => -10.0f64..10.0,
+            3 => -45.0f64..-20.0,
+            3 => 20.0f64..45.0,
+            2 => -400.0f64..-90.0,
+            2 => 90.0f64..400.0,
+        ]
+    }
+
+    proptest! {
+        /// `propagate_universal` must never panic, regardless of orbital
+        /// regime or gap length: it must always resolve to `Ok`/`Err`, and
+        /// every field of an `Ok` result must be finite.
+        #[test]
+        fn prop_no_panic_ever(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            let result = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type());
+            if let Ok(r) = result {
+                prop_assert!(r.r1.iter().all(|x| x.is_finite()));
+                prop_assert!(r.v1.iter().all(|x| x.is_finite()));
+                prop_assert!(r.f_lag.is_finite());
+                prop_assert!(r.g_lag.is_finite());
+                prop_assert!(r.f_dot.is_finite());
+                prop_assert!(r.g_dot.is_finite());
+                prop_assert!(r.psy.is_finite());
+            }
+        }
+
+        /// The Lagrange identity `f * g_dot - g * f_dot = 1` must hold to
+        /// near machine precision for every converged propagation.
+        #[test]
+        fn prop_lagrange_identity(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            if let Ok(r) = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type()) {
+                let identity = r.f_lag * r.g_dot - r.g_lag * r.f_dot;
+                prop_assert!(
+                    (identity - 1.0).abs() < 1e-8,
+                    "Lagrange identity violated: f*gdot - g*fdot = {identity}"
+                );
+            }
+        }
+
+        /// Specific orbital energy (hence `alpha`) is conserved by two-body
+        /// dynamics: recomputing it from `(r1, v1)` must match the value
+        /// from `(r0, v0)`.
+        #[test]
+        fn prop_energy_conserved(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            if let Ok(r) = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type()) {
+                let alpha_before = specific_energy_alpha(&position, &velocity);
+                let alpha_after = specific_energy_alpha(&r.r1, &r.v1);
+                let scale = 1.0 + alpha_before.abs();
+                prop_assert!(
+                    (alpha_after - alpha_before).abs() < 1e-8 * scale,
+                    "energy not conserved: before={alpha_before}, after={alpha_after}"
+                );
+            }
+        }
+
+        /// Angular momentum norm `|r x v|` is conserved by two-body
+        /// dynamics (planar, central-force motion).
+        #[test]
+        fn prop_angular_momentum_conserved(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            if let Ok(r) = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type()) {
+                let h_before = position.cross(&velocity).norm();
+                let h_after = r.r1.cross(&r.v1).norm();
+                let scale = 1.0 + h_before;
+                prop_assert!(
+                    (h_after - h_before).abs() < 1e-8 * scale,
+                    "angular momentum not conserved: before={h_before}, after={h_after}"
+                );
+            }
+        }
+
+        /// Propagating forward by `dt` then backward by the same `dt` must
+        /// recover the original state. This is the strongest invariant here:
+        /// it needs no external ground truth and directly catches unit/scale
+        /// regressions like the one fixed alongside `test_propag`.
+        #[test]
+        fn prop_round_trip(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            if let Ok(fwd) = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type()) {
+                if let Ok(back) = propagate_universal(&fwd.r1, &fwd.v1, T0 + dt, T0, default_solver_type()) {
+                    let position_scale = 1.0 + position.norm();
+                    let velocity_scale = 1.0 + velocity.norm();
+                    prop_assert!(
+                        (back.r1 - position).norm() < 1e-7 * position_scale,
+                        "round-trip position mismatch: {:?} vs {:?}", back.r1, position
+                    );
+                    prop_assert!(
+                        (back.v1 - velocity).norm() < 1e-7 * velocity_scale,
+                        "round-trip velocity mismatch: {:?} vs {:?}", back.v1, velocity
+                    );
+                }
+            }
+        }
+
+        /// When both solvers converge, `NewtonRaphson` and `BrentDecker`
+        /// must agree on the propagated state.
+        #[test]
+        fn prop_solver_kind_agreement(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            let mut newton_solver_type = default_solver_type();
+            newton_solver_type.kind = SolverKind::NewtonRaphson;
+            let mut brent_solver_type = default_solver_type();
+            brent_solver_type.kind = SolverKind::BrentDecker;
+
+            let newton = propagate_universal(&position, &velocity, T0, T0 + dt, newton_solver_type);
+            let brent = propagate_universal(&position, &velocity, T0, T0 + dt, brent_solver_type);
+
+            if let (Ok(rn), Ok(rb)) = (newton, brent) {
+                let scale = 1.0 + rn.r1.norm();
+                prop_assert!((rn.r1 - rb.r1).norm() < 1e-7 * scale);
+                prop_assert!((rn.v1 - rb.v1).norm() < 1e-7 * scale);
+            }
+        }
+
+        /// Chaining several small, irregular propagation steps (mimicking a
+        /// real sequence of survey detections) must land close to a single
+        /// direct propagation over the same total time span.
+        #[test]
+        fn prop_chained_vs_single_step(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            let t1 = T0 + dt;
+            // Irregular, non-uniform fractions of the total span (sums to 1.0).
+            let fractions = [0.02, 0.28, 0.1, 0.6];
+            let mut times = vec![T0];
+            let mut acc = T0;
+            for f in fractions {
+                acc += dt * f;
+                times.push(acc);
+            }
+            *times.last_mut().unwrap() = t1; // avoid float drift on the endpoint
+
+            let mut pos = position;
+            let mut vel = velocity;
+            let mut chained_ok = true;
+            for window in times.windows(2) {
+                match propagate_universal(&pos, &vel, window[0], window[1], default_solver_type()) {
+                    Ok(r) => {
+                        pos = r.r1;
+                        vel = r.v1;
+                    }
+                    Err(_) => {
+                        chained_ok = false;
+                        break;
+                    }
+                }
+            }
+
+            if chained_ok {
+                if let Ok(direct) = propagate_universal(&position, &velocity, T0, t1, default_solver_type()) {
+                    let position_scale = 1.0 + direct.r1.norm();
+                    let velocity_scale = 1.0 + direct.v1.norm();
+                    prop_assert!(
+                        (pos - direct.r1).norm() < 1e-6 * position_scale,
+                        "chained vs single-step position mismatch: {:?} vs {:?}", pos, direct.r1
+                    );
+                    prop_assert!(
+                        (vel - direct.v1).norm() < 1e-6 * velocity_scale,
+                        "chained vs single-step velocity mismatch: {:?} vs {:?}", vel, direct.v1
+                    );
+                }
+            }
+        }
+
+        /// A tiny relative perturbation (`1e-8`) of the initial position
+        /// must not produce a disproportionate change in the propagated
+        /// position — guards against pathological ill-conditioning (e.g.
+        /// near an internal solver-branch boundary).
+        #[test]
+        fn prop_continuity_position_perturbation(
+            (position, velocity) in arb_heliocentric_state(),
+            dt in arb_time_of_flight(),
+        ) {
+            const EPS: f64 = 1e-8;
+            if let Ok(base) = propagate_universal(&position, &velocity, T0, T0 + dt, default_solver_type()) {
+                let perturbed_position = position * (1.0 + EPS);
+                if let Ok(perturbed) = propagate_universal(&perturbed_position, &velocity, T0, T0 + dt, default_solver_type()) {
+                    let input_delta = (perturbed_position - position).norm();
+                    let output_delta = (perturbed.r1 - base.r1).norm();
+                    let output_scale = 1.0 + base.r1.norm();
+                    prop_assert!(
+                        output_delta < 1.0e6 * input_delta.max(1e-300) + 1e-9 * output_scale,
+                        "position perturbation amplified disproportionately: input_delta={input_delta}, output_delta={output_delta}"
+                    );
+                }
+            }
+        }
+    }
 }

--- a/src/kepler/universal_kepler_solution.rs
+++ b/src/kepler/universal_kepler_solution.rs
@@ -18,7 +18,11 @@
 ///
 /// A single equation covers all regimes:
 ///
-/// $$r_0 \cdot s_1(\psi, \alpha) + \sigma_0 \cdot s_2(\psi, \alpha) + \mu \cdot s_3(\psi, \alpha) = \Delta t$$
+/// $$r_0 \cdot s_1(\psi, \alpha) + \sigma_0 \cdot s_2(\psi, \alpha) + s_3(\psi, \alpha) = \sqrt{\mu} \cdot \Delta t$$
+///
+/// where `alpha` is the reciprocal semi-major-axis convention
+/// ( $\alpha = -1/a$ ), not the raw vis-viva $2E$ — see
+/// [`UniversalKeplerParams`](crate::kepler::UniversalKeplerParams).
 ///
 /// ## Stumpff auxiliary functions $s_n(\psi, \alpha)$
 ///
@@ -46,7 +50,7 @@
 ///
 /// which directly yields the residual derivative:
 ///
-/// $$f'(\psi) = r_0 \cdot s_0 + \sigma_0 \cdot s_1 + \mu \cdot s_2$$
+/// $$f'(\psi) = r_0 \cdot s_0 + \sigma_0 \cdot s_1 + s_2$$
 ///
 /// ## Role of each $s_n$ in orbit propagation
 ///
@@ -68,7 +72,7 @@ pub struct UniversalKeplerSolution {
     ///
     /// The root of the universal Kepler equation:
     ///
-    /// $$f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + \mu \cdot s_3 - \Delta t = 0$$
+    /// $$f(\psi) = r_0 \cdot s_1 + \sigma_0 \cdot s_2 + s_3 - \sqrt{\mu} \cdot \Delta t = 0$$
     pub universal_anomaly: f64,
 
     /// $s_0(\psi, \alpha)$ — cosine-like Stumpff function.

--- a/src/kepler/velocity.rs
+++ b/src/kepler/velocity.rs
@@ -103,7 +103,7 @@ pub fn velocity_correction_with_guess(
 ) -> Result<(Vector3<f64>, f64, f64, f64), OutfitError> {
     let gravitational_parameter = GAUSS_GRAV_SQUARED;
     let radius_at_t2 = x2.norm();
-    let radial_velocity_proxy_at_t2 = x2.dot(v2);
+    let radial_velocity_proxy_at_t2 = x2.dot(v2) / gravitational_parameter.sqrt();
 
     // Quick reject: near-zero angular momentum means rectilinear, unstable motion.
     reject_if_angular_momentum_is_degenerate(x2, v2)?;
@@ -117,12 +117,16 @@ pub fn velocity_correction_with_guess(
     ))?;
 
     // Step 2: pack parameters for the universal Kepler solver.
+    // `alpha` uses the reciprocal semi-major-axis convention (alpha = -1/a =
+    // 2E/mu) expected by the Stumpff engine, not the raw vis-viva `2E` —
+    // dividing by `mu` here is what keeps `alpha` and the Lagrange
+    // coefficients below (which carry no explicit `mu` factor) consistent.
     let params = UniversalKeplerParams {
         dt,
         r0: radius_at_t2,
         sig0: radial_velocity_proxy_at_t2,
         mu: gravitational_parameter,
-        alpha: 2.0 * specific_orbital_energy, // specific orbital energy -> alpha
+        alpha: 2.0 * specific_orbital_energy / gravitational_parameter,
         e0: eccentricity,
         solver_type: SolverType {
             params: SolverParams {
@@ -140,8 +144,8 @@ pub fn velocity_correction_with_guess(
     let (_, _, s2, s3) = kepler_solution.as_raw_stumpff();
 
     // Step 4: compute the Lagrange coefficients f and g.
-    let f_coefficient = 1.0 - (gravitational_parameter * s2) / radius_at_t2;
-    let g_coefficient = dt - (gravitational_parameter * s3);
+    let f_coefficient = 1.0 - s2 / radius_at_t2;
+    let g_coefficient = dt - s3 / gravitational_parameter.sqrt();
 
     // Guard against an ill-conditioned g (division instability).
     reject_if_lagrange_g_is_unstable(g_coefficient, dt)?;
@@ -335,7 +339,7 @@ mod tests_velocity_correction {
 
         let (v2, f, g) = velocity_correction(&x1, &x2, &v2, dt, 1., 1., KEP_EPS).unwrap();
 
-        assert_eq!(f, 0.988_164_877_097_290_6);
+        assert_eq!(f, 0.9881648770972906);
         assert_eq!(g, 14.674676076120734);
         assert_eq!(
             v2.as_slice(),

--- a/tests/test_gauss_iod.rs
+++ b/tests/test_gauss_iod.rs
@@ -67,7 +67,7 @@ fn expected_results() -> Vec<ExpectedResult> {
                 uncertainty: None,
                 covariance: None,
             },
-            rms: 18.963755528781288,
+            rms: 18.963755533886232,
         },
     ]
 }

--- a/tests/test_iod_from_polars.rs
+++ b/tests/test_iod_from_polars.rs
@@ -132,12 +132,12 @@ fn test_iod_from_polars() {
     let expected_orbit = OrbitalElements::Keplerian {
         elements: KeplerianElements {
             reference_epoch: 60894.252965553926,
-            semi_major_axis: 1.24701989952089,
-            eccentricity: 0.2082069422196415,
-            inclination: 0.08116316040114972,
-            ascending_node_longitude: 2.49554922649176,
-            periapsis_argument: 2.5470318525197477,
-            mean_anomaly: 0.2983936748249412,
+            semi_major_axis: 1.2470198995234851,
+            eccentricity: 0.20820694222020417,
+            inclination: 0.08116316040090545,
+            ascending_node_longitude: 2.4955492264777863,
+            periapsis_argument: 2.5470318525400066,
+            mean_anomaly: 0.2983936748196788,
         },
         uncertainty: None,
         covariance: None,
@@ -146,7 +146,7 @@ fn test_iod_from_polars() {
     assert!(approx_equal(&expected_orbit, orbit, test_epsilon));
     assert_relative_eq!(
         best_orbit.orbit_quality(),
-        0.010284390096535293,
+        0.010284425699399564,
         epsilon = test_epsilon,
         max_relative = test_max_relative
     );


### PR DESCRIPTION
`propagate_universal` used `alpha = 2E` (raw vis-viva energy) where the
Stumpff engine, residual/derivative equations, Lagrange f/g coefficients,
and `prelim_*` initial-guess heuristics actually require `alpha = -1/a`.
This caused non-convergence / wrong solutions on real fink-fat Kalman-filter
states (reproduced in `test_propag`).

A second bug in `velocity.rs` (Gauss IOD refinement) never divided `sig0`
by `sqrt(mu)`.

Both fixed across `propagation.rs`, `newton_solver.rs`,
`brent_dekker_solver.rs`, `prelim_elliptic/hyperbolic/parabolic.rs`, and
`velocity.rs`. Verified against independent two-body ODE integration and
against the Orbfit reference test (`test_solve_orbit`), which now matches
to 1e-13.
